### PR TITLE
Add redirect for root route

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { supabase } from '../lib/supabase';
+
+export default function Index() {
+  const router = useRouter();
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session && session.user) {
+        router.replace('/Chat');
+      } else {
+        router.replace('/Login');
+      }
+    });
+  }, [router]);
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- route root index to login or chat depending on auth status

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d7ef579c8320a8e250853c50ce06